### PR TITLE
SpacevimFindFiles: pass current file path

### DIFF
--- a/plugin/spacevim.vim
+++ b/plugin/spacevim.vim
@@ -331,7 +331,7 @@ endfunction
 
 function! SpacevimFindFiles()
   if exists(':Files')
-    execute "Files"
+    execute "Files %:h"
   elseif exists('g:loaded_unite')
     execute "Unite -start-insert file"
   elseif exists('g:loaded_ctrlp')


### PR DESCRIPTION
For some reason `:Files` doesn't use the correct path sometimes. This fixes that.
