### PR TITLE
Make leaderGuide truly optional

### DIFF
--- a/plugin/spacevim.vim
+++ b/plugin/spacevim.vim
@@ -10,11 +10,11 @@ let g:loaded_spacevim = 1
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Optionally integrate with vim-leader-guide
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-if exists('loaded_leaderGuide_vim')
-  if !exists('g:lmap')
-    let g:lmap = {}
-  endif
+if !exists('g:lmap')
+  let g:lmap = {}
+endif
 
+if exists('loaded_leaderGuide_vim')
   function! s:spacevim_displayfunc()
     let g:leaderGuide#displayname = substitute(g:leaderGuide#displayname, '\c<cr>$', '', '')
     let g:leaderGuide#displayname = substitute(g:leaderGuide#displayname, '^<SID>', '', '')


### PR DESCRIPTION
Without this commit, not having leaderguide installed gives errors for undefined
variable g:lmap.
