### PR TITLE
Rename loop variable used for additional plugins

### DIFF
--- a/autoload/spacevim.vim
+++ b/autoload/spacevim.vim
@@ -97,8 +97,8 @@ function! spacevim#bootstrap() abort
       endfor
     endfor
     if exists('g:dotspacevim_additional_plugins')
-      for plugin in g:dotspacevim_additional_plugins
-        Plug plugin
+      for additional_plugin in g:dotspacevim_additional_plugins
+        Plug additional_plugin
       endfor
     endif
     call plug#end()


### PR DESCRIPTION
I encountered this error loading spacevim with vim 7.4.576:

```
Error detected while processing function spacevim#bootstrap:
line   99:
E706: Variable type mismatch for: plugin
```

This prevented the gruvbox theme from being installed and my vim looking ugly.

Here's what's going on: the variable `plugin` is used in two places, first when iterating over `g:spacevim_plugins` and again when iterating over `g:dotspacevim_additional_plugins`. The error appears to be because `g:spacevim_plugins` contains dictionaries and `g:dotspacevim_additional_plugins` contains strings.

Giving the loop variable a different name solves the problem.
